### PR TITLE
Update for support of gnome 48

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,12 +6,13 @@
   "shell-version": [
     "45",
     "46",
-    "47"
+    "47",
+    "48"
   ],
   "url": "https://github.com/G-dH/gnome-colorblind-filters",
   "donations": {
     "buymeacoffee": "georgdh"
   },
   "uuid": "colorblind-filters@G-dH.github.com",
-  "version-name": "47.0"
+  "version-name": "48.0"
 }


### PR DESCRIPTION
seems to work without any other modifications.

Thanks for this!


I use this every day to turn my screen "grayscale" to learn how things might look printed even if the software doesn't support it! very handy!